### PR TITLE
Add nix crate to improve signal handling in multi-thread application.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-compress 0.1.1",
- "nwind 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)",
+ "nwind 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1096,9 +1096,10 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nwind 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)",
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nwind 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "perf_event_open 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)",
+ "perf_event_open 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)",
  "sc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1206,6 +1207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "nwind"
 version = "0.1.0"
-source = "git+https://github.com/nokia/not-perf.git?rev=a8537b9#a8537b9dfb97d4edcc5ffc0bb53a5026bf38b7b0"
+source = "git+https://github.com/koute/not-perf.git?rev=c6b9635#c6b9635164ed67ca31495cc624352db3f010bfd0"
 dependencies = [
  "addr2line 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1259,7 +1272,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-maps 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)",
+ "proc-maps 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1329,7 +1342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "perf_event_open"
 version = "0.1.0"
-source = "git+https://github.com/nokia/not-perf.git?rev=a8537b9#a8537b9dfb97d4edcc5ffc0bb53a5026bf38b7b0"
+source = "git+https://github.com/koute/not-perf.git?rev=c6b9635#c6b9635164ed67ca31495cc624352db3f010bfd0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1376,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "proc-maps"
 version = "0.1.0"
-source = "git+https://github.com/nokia/not-perf.git?rev=a8537b9#a8537b9dfb97d4edcc5ffc0bb53a5026bf38b7b0"
+source = "git+https://github.com/koute/not-perf.git?rev=c6b9635#c6b9635164ed67ca31495cc624352db3f010bfd0"
 
 [[package]]
 name = "quick-error"
@@ -2364,25 +2377,26 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+"checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-format 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum nwind 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)" = "<none>"
+"checksum nwind 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)" = "<none>"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-"checksum perf_event_open 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)" = "<none>"
+"checksum perf_event_open 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)" = "<none>"
 "checksum plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "114cdf1f426eb7f550f01af5f53a33c0946156f6814aec939b3bd77e844f9a9d"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
-"checksum proc-maps 0.1.0 (git+https://github.com/nokia/not-perf.git?rev=a8537b9)" = "<none>"
+"checksum proc-maps 0.1.0 (git+https://github.com/koute/not-perf.git?rev=c6b9635)" = "<none>"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quick-xml 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1cd45021132c1cb5540995e93fcc2cf5a874ef84f9639168fb6819caa023d4be"
 "checksum quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5ca504a2fdaa08d3517f442fbbba91ac24d1ec4c51ea68688a038765e3b2662"

--- a/preload/Cargo.toml
+++ b/preload/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = "1"
 memmap = "0.7"
 log = "0.4"
 glob = "0.2"
+nix = "0.17"
 jemallocator = { path = "../jemallocator", default-features = false }
 jemalloc-sys = { path = "../jemallocator/jemalloc-sys", default-features = false }
 

--- a/preload/src/init.rs
+++ b/preload/src/init.rs
@@ -1,3 +1,4 @@
+use nix::sys::signal;
 use std::env;
 
 use crate::global::on_exit;
@@ -8,14 +9,14 @@ use crate::utils::generate_filename;
 fn initialize_logger() {
     static mut SYSCALL_LOGGER: logger::SyscallLogger = logger::SyscallLogger::empty();
     static mut FILE_LOGGER: logger::FileLogger = logger::FileLogger::empty();
-    let log_level = if let Ok( value ) = env::var( "MEMORY_PROFILER_LOG" ) {
+    let log_level = if let Ok(value) = env::var("MEMORY_PROFILER_LOG") {
         match value.as_str() {
             "trace" => log::LevelFilter::Trace,
             "debug" => log::LevelFilter::Debug,
             "info" => log::LevelFilter::Info,
             "warn" => log::LevelFilter::Warn,
             "error" => log::LevelFilter::Error,
-            _ => log::LevelFilter::Off
+            _ => log::LevelFilter::Off,
         }
     } else {
         log::LevelFilter::Off
@@ -23,65 +24,79 @@ fn initialize_logger() {
 
     let pid = unsafe { libc::getpid() };
 
-    if let Ok( value ) = env::var( "MEMORY_PROFILER_LOGFILE" ) {
-        let path = generate_filename( &value, None );
-        let rotate_at = env::var( "MEMORY_PROFILER_LOGFILE_ROTATE_WHEN_BIGGER_THAN" ).ok().and_then( |value| value.parse().ok() );
+    if let Ok(value) = env::var("MEMORY_PROFILER_LOGFILE") {
+        let path = generate_filename(&value, None);
+        let rotate_at = env::var("MEMORY_PROFILER_LOGFILE_ROTATE_WHEN_BIGGER_THAN")
+            .ok()
+            .and_then(|value| value.parse().ok());
 
         unsafe {
-            if let Ok(()) = FILE_LOGGER.initialize( path, rotate_at, log_level, pid ) {
-                log::set_logger( &FILE_LOGGER ).unwrap();
+            if let Ok(()) = FILE_LOGGER.initialize(path, rotate_at, log_level, pid) {
+                log::set_logger(&FILE_LOGGER).unwrap();
             }
         }
     } else {
         unsafe {
-            SYSCALL_LOGGER.initialize( log_level, pid );
-            log::set_logger( &SYSCALL_LOGGER ).unwrap();
+            SYSCALL_LOGGER.initialize(log_level, pid);
+            log::set_logger(&SYSCALL_LOGGER).unwrap();
         }
     }
 
-    log::set_max_level( log_level );
+    log::set_max_level(log_level);
 }
 
 fn initialize_atexit_hook() {
-    info!( "Setting atexit hook..." );
+    info!("Setting atexit hook...");
     unsafe {
-        let result = libc::atexit( on_exit );
+        let result = libc::atexit(on_exit);
         if result != 0 {
-            error!( "Cannot set the at-exit hook" );
+            error!("Cannot set the at-exit hook");
         }
     }
 }
 
 fn initialize_signal_handlers() {
-    extern "C" fn sigusr_handler( signal: libc::c_int ) {
-        let signal_name = match signal {
-            libc::SIGUSR1 => "SIGUSR1",
-            libc::SIGUSR2 => "SIGUSR2",
-            _ => "???"
-        };
-
-        info!( "Signal handler triggered with signal: {} ({})", signal_name, signal );
-        crate::global::toggle();
+    if !opt::get().register_sigusr1 && !opt::get().register_sigusr2 {
+        info!("Skip signal register.");
+        return;
     }
-
+    let mut sigset = signal::SigSet::empty();
     if opt::get().register_sigusr1 {
-        info!( "Registering SIGUSR1 handler..." );
-        unsafe {
-            libc::signal( libc::SIGUSR1, sigusr_handler as libc::sighandler_t );
-        }
+        sigset.add(signal::Signal::SIGUSR1);
+        info!("Registering SIGUSR1 handler...");
     }
-
     if opt::get().register_sigusr2 {
-        info!( "Registering SIGUSR2 handler..." );
-        unsafe {
-            libc::signal( libc::SIGUSR2, sigusr_handler as libc::sighandler_t );
-        }
+        sigset.add(signal::Signal::SIGUSR2);
+        info!("Registering SIGUSR2 handler...");
     }
+    sigset.thread_block().expect("Register signal failed!");
+
+    thread::Builder::new()
+        .name("Sigwait".into())
+        .spawn(move || loop {
+            match sigset.wait() {
+                Ok(sig) => {
+                    let signal_name = match sig {
+                        signal::Signal::SIGUSR1 => "SIGUSR1",
+                        signal::Signal::SIGUSR2 => "SIGUSR2",
+                        _ => "???",
+                    };
+
+                    info!(
+                        "Signal handler triggered with signal: {} ({})",
+                        signal_name, sig
+                    );
+                    crate::global::toggle();
+                }
+                Err(e) => error!("Signal wait error: {}", e),
+            }
+        })
+        .expect("Failed to start Sigwait thread");
 }
 
 pub fn startup() {
     initialize_logger();
-    info!( "Version: {}", env!( "CARGO_PKG_VERSION" ) );
+    info!("Version: {}", env!("CARGO_PKG_VERSION"));
 
     unsafe {
         opt::initialize();
@@ -94,6 +109,6 @@ pub fn startup() {
 
     initialize_signal_handlers();
 
-    env::remove_var( "LD_PRELOAD" );
-    info!( "Startup initialization finished" );
+    env::remove_var("LD_PRELOAD");
+    info!("Startup initialization finished");
 }


### PR DESCRIPTION
The `libc::signal` function might not be work at some OS for multi-thread application.