### PR TITLE
fix `backtracs_storage` slice index wrapping

### DIFF
--- a/cli-core/src/data.rs
+++ b/cli-core/src/data.rs
@@ -739,7 +739,7 @@ impl Data {
     #[inline]
     pub fn get_frame_ids( &self, id: BacktraceId ) -> &[FrameId] {
         let (offset, length) = self.backtraces[ id.0 as usize ];
-        &self.backtraces_storage[ (offset as usize)..(offset + length) as usize ]
+        &self.backtraces_storage[ (offset as usize)..(offset as usize + length as usize) ]
     }
 
     pub fn get_frame( &self, id: FrameId ) -> &Frame {

--- a/cli-core/src/loader.rs
+++ b/cli-core/src/loader.rs
@@ -1028,7 +1028,7 @@ impl Loader {
 
         for (raw_backtrace_id, stats) in self.group_stats.iter().enumerate() {
             let (backtrace_offset, backtrace_len) = self.backtraces[ raw_backtrace_id ];
-            for &frame_id in &self.backtraces_storage[ backtrace_offset as usize..(backtrace_offset + backtrace_len) as usize ] {
+            for &frame_id in &self.backtraces_storage[ backtrace_offset as usize..(backtrace_offset as usize + backtrace_len as usize) ] {
                 self.frames[ frame_id ].increment_count( stats.alloc_count );
             }
         }


### PR DESCRIPTION
This PR fixes a couple of instances of panics I encountered when
attempting to load and view a large data file with the cli server. I'm
not entirely sure the fixes are correct, since I don't fully understand
the intent of the code, in particular why `backtrace_offset` is
guaranteed to be fit an a `u32` if `backtrace_offset + backtrace_len`
can not.

Example panic backtrace:

```
thread '<unnamed>' panicked at 'slice index starts at 4294967290 but ends at 391', cli-core/src/data.rs:708:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/panicking.rs:93:14
   2: core::slice::index::slice_index_order_fail
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/slice/index.rs:48:5
   3: server_core::filter::match_allocation
   4: server_core::get_allocations::{{closure}}
             at ./server-core/src/lib.rs:652:31
   5: <core::iter::adapters::filter::Filter<I,P> as core::iter::traits::iterator::Iterator>::count::to_usize::{{closure}}
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/adapters/filter.rs:80:22
   6: core::iter::adapters::map::map_fold::{{closure}}
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/adapters/map.rs:84:28
   7: core::iter::adapters::map::map_fold::{{closure}}
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/adapters/map.rs:84:21
   8: core::iter::traits::iterator::Iterator::fold
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/traits/iterator.rs:2174:21
   9: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/adapters/map.rs:124:9
  10: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/adapters/map.rs:124:9
  11: <usize as core::iter::traits::accum::Sum>::sum
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/traits/accum.rs:42:17
  12: core::iter::traits::iterator::Iterator::sum
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/traits/iterator.rs:3000:9
  13: <core::iter::adapters::filter::Filter<I,P> as core::iter::traits::iterator::Iterator>::count
             at /rustc/25b764849625cb090e8b81d12d2bb2295d073788/library/core/src/iter/adapters/filter.rs:83:9
  14: server_core::get_allocations
             at ./server-core/src/lib.rs:650:9
  15: server_core::handler_allocations::{{closure}}
             at ./server-core/src/lib.rs:702:24
  16: server_core::async_data_handler::{{closure}}
             at ./server-core/src/lib.rs:208:9
```